### PR TITLE
docs: Fix simple typo, accces -> access

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -34,7 +34,7 @@ is called. ``atexit`` is used to register ``Mailer.stop`` to shutdown when wsgi 
 Note that ``pyramid_marrowmailer`` subclasses ``marrow.mailer.Mailer`` to provide support for
 ``transaction``. Class is importable from ``pyramid_marrowmailer.TransactionMailer``.
 
-You can accces ``pyramid_marrowmailer.TransactionMailer`` instance in two ways::
+You can access ``pyramid_marrowmailer.TransactionMailer`` instance in two ways::
 
     message = request.mailer.new()
     ...


### PR DESCRIPTION
There is a small typo in README.rst.

Should read `access` rather than `accces`.

